### PR TITLE
perf: reduce call api nvim_win_get_width :muscle: 

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ basic.lsp_diagnos = {
         yellow = { 'yellow', 'black' },
         blue = { 'blue', 'black' },
     },
-    text = function(bufnr, winnr)
+    text = function(bufnr, winnr, width)
         if lsp_comps.check_lsp() then
             return {
                 -- `red` is define in hl_colors or a hightlight group name

--- a/lua/windline/component.lua
+++ b/lua/windline/component.lua
@@ -84,16 +84,16 @@ function Comp:setup_hl(colors)
 end
 
 
-function Comp:render(bufnr, winnr)
+function Comp:render(bufnr, winnr, width)
     self.bufnr = bufnr
     local hl_data = self.hl_data or {}
-    local childs = self.text(self.bufnr, winnr)
+    local childs = self.text(bufnr, winnr, width)
     if type(childs) == 'table'then
         local result = ''
         for _,child in pairs(childs) do
             local text,hl = child[1],child[2]
             if type(text) == 'function' then
-                text = child[1](bufnr, winnr)
+                text = child[1](bufnr, winnr, width)
             end
             if type(hl) == 'string' then
                 hl = hl_data[hl] or hl

--- a/lua/wlsample/airline.lua
+++ b/lua/wlsample/airline.lua
@@ -62,14 +62,11 @@ airline_colors.c = {
 basic.divider = { b_components.divider, hl_list.Normal }
 
 local width_breakpoint = 100
-local check_width = function()
-    return vim.fn.winwidth(0) > width_breakpoint
-end
 
 basic.section_a = {
     hl_colors = airline_colors.a,
-    text = function()
-        if check_width() then
+    text = function(_,_,width)
+        if width > width_breakpoint then
             return {
                 { ' ' .. state.mode[1] .. ' ', state.mode[2] },
                 { sep.right_filled, state.mode[2] .. 'Sep' },
@@ -86,9 +83,9 @@ local get_git_branch = git_comps.git_branch()
 
 basic.section_b = {
     hl_colors = airline_colors.b,
-    text = function()
+    text = function(_,_, width)
         local branch_name = get_git_branch()
-        if check_width() and #branch_name > 1 then
+        if width > width_breakpoint and #branch_name > 1 then
             return {
                 { branch_name , state.mode[2] },
                 { ' ', '' },
@@ -128,8 +125,8 @@ basic.section_x = {
 
 basic.section_y = {
     hl_colors = airline_colors.b,
-    text = function()
-        if check_width() then
+    text = function(_,_,width)
+        if width > width_breakpoint then
             return {
                 { sep.left_filled, state.mode[2] .. 'Sep' },
                 { b_components.file_type({ icon = true }), state.mode[2] },
@@ -142,8 +139,8 @@ basic.section_y = {
 
 basic.section_z = {
     hl_colors = airline_colors.a,
-    text = function()
-        if check_width() then
+    text = function(_,_,width)
+        if width > width_breakpoint then
             return {
                 { sep.left_filled, state.mode[2] .. 'Sep' },
                 { '', state.mode[2] },
@@ -154,6 +151,7 @@ basic.section_z = {
         end
         return {
             { sep.left_filled, state.mode[2] .. 'Sep' },
+            { ' ', state.mode[2] },
             { b_components.line_col, state.mode[2] },
         }
     end,

--- a/lua/wlsample/evil_line.lua
+++ b/lua/wlsample/evil_line.lua
@@ -67,8 +67,8 @@ basic.file = {
         white = { 'white', 'black' },
         magenta = { 'magenta', 'black' },
     },
-    text = function(_, winnr)
-        if vim.api.nvim_win_get_width(winnr) > breakpoint_width then
+    text = function(_, _, width)
+        if width > breakpoint_width then
             return {
                 { b_components.cache_file_size(), 'default' },
                 { ' ', '' },
@@ -95,8 +95,8 @@ basic.file_right = {
         white = { 'white', 'black' },
         magenta = { 'magenta', 'black' },
     },
-    text = function(_, winnr)
-        if vim.api.nvim_win_get_width(winnr) < breakpoint_width then
+    text = function(_, _, width)
+        if width < breakpoint_width then
             return {
                 { b_components.line_col, 'white' },
                 { b_components.progress, '' },


### PR DESCRIPTION
I just realize we usually call nvim_win_get_width function on the component
so I call it from render and send it to a component by params

benchmark
- evil_line reduce from 0.13 to 0.125
- airline reduce from 0.23 to 0.21