### PR TITLE
fix: change in_active to more clear words

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ local explorer = {
 
     --- show active components when the window is inactive
     always_active = true,
-    --- it will display a last window status event that window should inactive
+    --- it will display a last window statusline even that window should inactive
     show_last_status = true
 }
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ local yourstatus = {
         {' lspcrazy ', {'white', 'black'} },
         {function() return 'crazy' end ,{'black', 'red'} },
     },
-    show_in_active = true
+    always_active = true
 }
 
 ```
@@ -133,7 +133,7 @@ local default = {
     active={
       --- components...
     },
-    in_active={
+    inactive={
       --- components...
     }
 }
@@ -145,7 +145,7 @@ local explorer = {
     },
 
     --- show active components when the window is inactive
-    show_in_active = true,
+    always_active = true,
     --- it will display a last window status event that window should inactive
     show_last_status = true
 }

--- a/lua/windline/init.lua
+++ b/lua/windline/init.lua
@@ -201,7 +201,7 @@ M.add_status = function(lines)
     -- FIXME update change. It will be remove on the future
     for _, line in ipairs(lines) do
         utils.update_check(line.in_active ~= nil,
-           "You need change 'in_active' to 'inactive'. ':%s/in_active/inactive/g'")
+           "You need to change status line 'in_active' to 'inactive'. ':%s/in_active/inactive/g'")
         line.inactive = line.inactive or line.in_active
         utils.update_check(line.show_in_active ~= nil,
         "You need change 'show_in_active' to 'always_active'. ':%s/show_in_active/always_active/g'")

--- a/lua/windline/init.lua
+++ b/lua/windline/init.lua
@@ -198,8 +198,13 @@ end
 
 
 M.add_status = function(lines)
+    -- FIXME update change. It will be remove on the future
     for _, line in ipairs(lines) do
+        utils.update_check(line.in_active ~= nil,
+           "You need change 'in_active' to 'inactive'. ':%s/in_active/inactive/g'")
         line.inactive = line.inactive or line.in_active
+        utils.update_check(line.show_in_active ~= nil,
+        "You need change 'show_in_active' to 'always_active'. ':%s/show_in_active/always_active/g'")
         line.always_active = line.always_active or line.show_in_active
     end
     if lines.filetypes then

--- a/lua/windline/init.lua
+++ b/lua/windline/init.lua
@@ -204,7 +204,7 @@ M.add_status = function(lines)
            "You need to change status line 'in_active' to 'inactive'. ':%s/in_active/inactive/g'")
         line.inactive = line.inactive or line.in_active
         utils.update_check(line.show_in_active ~= nil,
-        "You need change 'show_in_active' to 'always_active'. ':%s/show_in_active/always_active/g'")
+        "You need to change status line 'show_in_active' to 'always_active'. ':%s/show_in_active/always_active/g'")
         line.always_active = line.always_active or line.show_in_active
     end
     if lines.filetypes then

--- a/lua/windline/init.lua
+++ b/lua/windline/init.lua
@@ -65,18 +65,18 @@ M.show = function(bufnr, winnr)
         else
             if line then
                 -- render active even that component on_inactive
-                if line.show_in_active == true then
+                if line.always_active == true then
                     return render(bufnr, winnr, line.active)
                 end
-                if line.in_active then
-                    return render(bufnr, winnr, line.in_active)
+                if line.inactive then
+                    return render(bufnr, winnr, line.inactive)
                 end
             end
-            -- make an in_active render like the last active
+            -- make an inactive render like the last active
             if M.state.last_status_win == vim.g.statusline_winid then
                 return M.state.cache_last_status
             end
-            return render(bufnr, winnr, M.default_line.in_active)
+            return render(bufnr, winnr, M.default_line.inactive)
         end
     else
         -- active
@@ -124,7 +124,7 @@ end
 local setup_hightlight = function(colors)
     assert(M.default_line ~= nil, 'you need define default statusline')
     assert(M.default_line.active ~= nil, 'default need list active componet')
-    assert(M.default_line.in_active ~= nil, 'default need list in_active component')
+    assert(M.default_line.inactive ~= nil, 'default need list inactive component')
 
     if M.anim_pause then M.anim_pause() end
 
@@ -137,10 +137,10 @@ local setup_hightlight = function(colors)
 
     for _, line in pairs(M.statusline_ft) do
         M.create_comp_list(line.active, colors)
-        M.create_comp_list(line.in_active, colors)
+        M.create_comp_list(line.inactive, colors)
     end
     M.create_comp_list(M.default_line.active, colors)
-    M.create_comp_list(M.default_line.in_active, colors)
+    M.create_comp_list(M.default_line.inactive, colors)
     utils.hl_create()
 
     if M.anim_run then M.anim_run() end
@@ -198,6 +198,10 @@ end
 
 
 M.add_status = function(lines)
+    for _, line in ipairs(lines) do
+        line.inactive = line.inactive or line.in_active
+        line.always_active = line.always_active or line.show_in_active
+    end
     if lines.filetypes then
         table.insert(M.statusline_ft, lines)
     else

--- a/lua/windline/utils.lua
+++ b/lua/windline/utils.lua
@@ -141,4 +141,9 @@ M.get_unique_bufname = function(bufnr)
     return string.reverse(string.sub(tmp_name, 1, position))
 end
 
+M.update_check = function(check, message)
+    if check then
+        vim.notify("WindLine Update: " .. message)
+    end
+end
 return M

--- a/lua/wlsample/airline.lua
+++ b/lua/wlsample/airline.lua
@@ -215,7 +215,7 @@ local quickfix = {
         { helper.separators.slant_right, { 'InactiveBg', 'black' } },
         { '🧛 ', { 'white', 'black' } },
     },
-    show_in_active = true,
+    always_active = true,
 }
 
 local explorer = {
@@ -226,7 +226,7 @@ local explorer = {
         { b_components.divider, '' },
         { b_components.file_name(''), { 'white', 'black_light' } },
     },
-    show_in_active = true,
+    show_in_inactive = true,
     show_last_status = true
 }
 

--- a/lua/wlsample/airline_anim.lua
+++ b/lua/wlsample/airline_anim.lua
@@ -197,7 +197,7 @@ local default = {
         basic.section_y,
         basic.section_z,
     },
-    in_active = {
+    inactive = {
         { b_components.full_file_name, hl_list.Inactive },
         { b_components.divider, hl_list.Inactive },
         { b_components.line_col, hl_list.Inactive },

--- a/lua/wlsample/airline_luffy.lua
+++ b/lua/wlsample/airline_luffy.lua
@@ -120,7 +120,7 @@ local default = {
         basic.right_sep,
         basic.right,
     },
-    in_active = {
+    inactive = {
         { b_components.full_file_name, hl_list.Inactive },
         basic.divider,
         basic.divider,

--- a/lua/wlsample/basic.lua
+++ b/lua/wlsample/basic.lua
@@ -82,7 +82,7 @@ local explorer = {
         basic.divider,
         basic.explorer_name,
     },
-    show_in_active = true
+    always_active = true
 }
 
 
@@ -132,7 +132,7 @@ local terminal = {
         {sep.slant_right_thin,{'white','InactiveBg'}},
         basic.progress_inactive,
     },
-    show_in_active = true
+    always_active = true
 }
 
 local default = {
@@ -155,7 +155,7 @@ local default = {
         basic.progress
 
     },
-    in_active={
+    inactive={
         basic.file_name_inactive,
         basic.divider,
         basic.divider,

--- a/lua/wlsample/bubble.lua
+++ b/lua/wlsample/bubble.lua
@@ -141,7 +141,7 @@ local default = {
         basic.right,
         { ' ', hl_list.Black },
     },
-    in_active = {
+    inactive = {
         basic.file_name_inactive,
         basic.divider,
         basic.divider,
@@ -169,7 +169,7 @@ local quickfix = {
         { helper.separators.slant_right, { 'InactiveBg', 'black' } },
         { '🧛 ', { 'white', 'black' } },
     },
-    show_in_active = true,
+    always_active = true,
 }
 
 local explorer = {
@@ -180,7 +180,7 @@ local explorer = {
         { b_components.divider, '' },
         { b_components.file_name(''), { 'white', 'black_light' } },
     },
-    show_in_active = true,
+    always_active = true,
     show_last_status = true
 }
 

--- a/lua/wlsample/bubble2.lua
+++ b/lua/wlsample/bubble2.lua
@@ -150,7 +150,7 @@ local default = {
         basic.right,
         { ' ', hl_list.Black },
     },
-    in_active = {
+    inactive = {
         basic.file_name_inactive,
         basic.divider,
         basic.divider,
@@ -178,7 +178,7 @@ local quickfix = {
         { helper.separators.slant_right, { 'InactiveBg', 'black' } },
         { '🧛 ', { 'white', 'black' } },
     },
-    show_in_active = true,
+    always_active = true,
 }
 
 local explorer = {
@@ -189,7 +189,7 @@ local explorer = {
         { b_components.divider, '' },
         { b_components.file_name(''), { 'white', 'black_light' } },
     },
-    show_in_active = true,
+    always_active = true,
     show_last_status = true
 }
 windline.setup({

--- a/lua/wlsample/evil_line.lua
+++ b/lua/wlsample/evil_line.lua
@@ -144,7 +144,7 @@ local quickfix = {
         { '🧛 ', { 'white', 'black' } },
     },
 
-    show_in_active = true,
+    always_active = true,
 }
 
 local explorer = {
@@ -155,7 +155,7 @@ local explorer = {
         { b_components.divider, '' },
         { b_components.file_name(''), { 'white', 'black_light' } },
     },
-    show_in_active = true,
+    always_active = true,
     show_last_status = true,
 }
 local default = {
@@ -173,7 +173,7 @@ local default = {
         { ' ', hl_list.Black },
         basic.square_mode,
     },
-    in_active = {
+    inactive = {
         { b_components.full_file_name, hl_list.Inactive },
         basic.file_name_inactive,
         basic.divider,

--- a/lua/wlsample/job_test.lua
+++ b/lua/wlsample/job_test.lua
@@ -137,7 +137,7 @@ local default = {
         basic.right_sep,
         basic.right,
     },
-    in_active = {
+    inactive = {
         { b_components.full_file_name, hl_list.Inactive },
         basic.divider,
         basic.divider,

--- a/lua/wlsample/music_bar.lua
+++ b/lua/wlsample/music_bar.lua
@@ -63,7 +63,7 @@ local default = {
     active = {
         basic.up,
     },
-    in_active = {
+    inactive = {
         { '', '' },
     },
 }

--- a/lua/wlsample/rainbow.lua
+++ b/lua/wlsample/rainbow.lua
@@ -117,7 +117,7 @@ local default = {
         basic.progress
 
     },
-    in_active={
+    inactive={
         basic.file_name_inactive,
         basic.divider,
         basic.divider,
@@ -182,8 +182,8 @@ local markdown = {
         basic.divider,
         {sep.left_rounded,{'red','black_light'}},
     },
-    show_in_active=true,
-    in_active={
+    always_active=true,
+    inactive={
         basic.file_name_inactive,
         basic.divider,
         basic.divider,

--- a/lua/wlsample/test_add_component.lua
+++ b/lua/wlsample/test_add_component.lua
@@ -211,7 +211,7 @@ local quickfix = {
         { helper.separators.slant_right, { 'InactiveBg', 'black' } },
         { '🧛 ', { 'white', 'black' } },
     },
-    show_in_active = true,
+    always_active = true,
 }
 
 local explorer = {
@@ -222,7 +222,7 @@ local explorer = {
         { b_components.divider, '' },
         { b_components.file_name(''), { 'white', 'black_light' } },
     },
-    show_in_active = true,
+    always_active = true,
     show_last_status = true,
 }
 
@@ -240,7 +240,7 @@ local default = {
         basic.section_y,
         basic.section_z,
     },
-    in_active = {
+    inactive = {
         { b_components.full_file_name, hl_list.Inactive },
         { b_components.divider, hl_list.Inactive },
         { b_components.line_col, hl_list.Inactive },

--- a/lua/wlsample/wind.lua
+++ b/lua/wlsample/wind.lua
@@ -151,7 +151,7 @@ local default = {
         basic.progress
 
     },
-    in_active={
+    inactive={
         basic.file_name_inactive,
         basic.divider,
         basic.divider,


### PR DESCRIPTION
This won't break compatibility, changes `in_active` for `inactive` and `show_in_inactive` for `show_while_inactive` and will make the documentation more clear.

I tested locally with the samples, if you like this approach test with your setup that perhaps is more complex.