### PR TITLE
fix typo for `lsp_names`

### DIFF
--- a/lua/windline/components/lsp.lua
+++ b/lua/windline/components/lsp.lua
@@ -33,7 +33,7 @@ local lsp_client_names = function(bufnr, opt)
     opt = opt or {}
     local clients = {}
     local icon = opt.icon or ' '
-    local sep = opt.seprator or '|'
+    local sep = opt.separator or '|'
 
     for _, client in pairs(vim.lsp.buf_get_clients(bufnr or 0)) do
         clients[#clients + 1] = client.name


### PR DESCRIPTION
hello, thank you for the plugin!
was searching for a way to customize separator for lsp component and found a typo