### PR TITLE
fix: explicitly set nil winid to 0

### DIFF
--- a/lua/windline/init.lua
+++ b/lua/windline/init.lua
@@ -23,6 +23,7 @@ local render = function(bufnr, winid, items, cache)
     M.state.mode = mode()
     Comp.reset()
     local status = ''
+    winid = winid or 0
     local win_width = api.nvim_win_is_valid(winid) and api.nvim_win_get_width(winid)
     for _, comp in pairs(items) do
         if win_width and (comp.width == nil or comp.width < win_width) then


### PR DESCRIPTION
I have only had this issue when opening a directory but there may be other cases where winid is nil.