### PR TITLE
Fix "cache component" link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ basic.lsp_diagnos = {
 }
 ```
 **Don't do something complex on component. It run multiple times when statusline
-rendering. If you want to do that you need to use** [cache component](https://github.com/windwp/windline.nvim/wik/component#cache-value-on-buffer)
+rendering. If you want to do that you need to use** [cache component](https://github.com/windwp/windline.nvim/wiki/component#cache-value-on-buffer)
 
 <h4>Never use a Job or run system command inside component. You need to use it
 inside cache component </h4>


### PR DESCRIPTION
Currently "cache component" link leads to 404. It's "wik" instead of "wiki".