### PR TITLE
Improve `file_size` component

### DIFF
--- a/lua/windline/components/basic.lua
+++ b/lua/windline/components/basic.lua
@@ -83,23 +83,41 @@ end
 
 M.file_size = function()
     return function()
-        local file = fn.expand('%:p')
-        if string.len(file) == 0 then
+        local path = vim.api.nvim_buf_get_name(0)
+
+        if string.len(path) == 0 then
             return ''
         end
-        local suffix = { 'b', 'k', 'M', 'G', 'T', 'P', 'E' }
+
+        local size = vim.fn.getfsize(path)
+
+        if size < 1 then
+            return ''
+        end
+
+        local suffixes = {
+            'B',
+            'kB',
+            'MB',
+            'GB',
+            'TB',
+            'PB',
+            'EB',
+        }
+
         local index = 1
 
-        local fsize = fn.getfsize(file)
-        if fsize < 1 then
-            return ''
-        end
-        while fsize > 1024 and index < 7 do
-            fsize = fsize / 1024
+        while
+            size >= 1000
+            and index < #suffixes
+        do
+            size = size / 1000
             index = index + 1
         end
 
-        return string.format('%.2f', fsize) .. suffix[index]
+        local rounded_size = math.ceil(size * 100 - 0.5) / 100
+
+        return rounded_size .. suffixes[index]
     end
 end
 


### PR DESCRIPTION
* Use `vim.api.nvim_buf_get_name(0)` instead of `vim.fn.expand('%:p')` for much better performance (based on my tests its about 100x faster) and seems like result is the same
* `byte` is usually represented as `B` while `b` would represent `bit`. I'm proposing to change `byte` representation from `b` to `B`.
* I think we can spare one extra character and end every suffix also with `B`
* Round result value with `math` instead of `string.format` so size for small files or round sizes look better. For example it will be `8B` instead of `8.00B`, `2.3MB` instead `2.30MB` etc
* Use factor of `1000` instead of `1024`, otherwise proper notation would be `KiB`, `MiB`, `GiB`, etc
* Make names of some variables more obvious and less cryptic

Benchmark of uncached `file_size` component improved by about 25%, but visuals are important too.

Let me know what do you think about these changes.